### PR TITLE
Adding NTotSC areas to BGEE worldmap

### DIFF
--- a/NTotSC/NTotSC.tp2
+++ b/NTotSC/NTotSC.tp2
@@ -2151,6 +2151,20 @@ END ELSE BEGIN
 	COPY ~NTotSC/language/%LANGUAGE%/worldmap.tra~ ~Worldmap/map_mods_trans.tra~
 END
 
+ACTION_IF GAME_IS ~bgee~ BEGIN
+	INCLUDE ~%MOD_FOLDER%/lib/add_worldmap_tbl.tpa~
+	LAF ADD_WORLDMAP_TBL
+		INT_VAR
+		verbose = 1
+		inclSv = 0
+		STR_VAR
+		path_to_areas = EVAL ~%MOD_FOLDER%/Worldmap/bgee/bgee_areas.tbl~
+		path_to_areas_bp = ~%MOD_FOLDER%/Worldmap/areas.tbl~
+		path_to_links = EVAL ~%MOD_FOLDER%/Worldmap/bgee/bgee_links.tbl~
+		path_to_trans = EVAL ~%MOD_FOLDER%/language/%LANGUAGE%/worldmap.tra~
+	END
+END
+
 ACTION_IF GAME_IS ~eet~ BEGIN
 	INCLUDE ~%MOD_FOLDER%/lib/add_worldmap_tbl.tpa~
 	LAF ADD_WORLDMAP_TBL

--- a/NTotSC/language/english/worldmap.tra
+++ b/NTotSC/language/english/worldmap.tra
@@ -5,3 +5,6 @@
 @NT_783004  = "Wood###of###the###Dead"
 @NT_783005  = "Northern###Citadel"
 @NT_783006  = "Temple###of###the###Black###Hand"
+
+#BGEE: 22853
+@NT_783010  = "Ulgoth's###Beard"

--- a/NTotSC/language/german/worldmap.tra
+++ b/NTotSC/language/german/worldmap.tra
@@ -5,3 +5,6 @@
 @NT_783004  = "Wald###der###Toten"
 @NT_783005  = "Nördliche###Zitadelle"
 @NT_783006  = "Tempel###der###Schwarzen###Hand"
+
+#BGEE: 22853
+@NT_783010  = "Ulgoths###Bart"

--- a/NTotSC/worldmap/bgee/bgee_areas.tbl
+++ b/NTotSC/worldmap/bgee/bgee_areas.tbl
@@ -1,0 +1,12 @@
+
+//BGEE Changes Areas
+SHORT_NAME  CONTENT  LONG_NAME  FLAGS  BAM_ANIM  X_POS  Y_POS  NAME         TOOLTIP      LOAD_IM
+
+AR20PB      AR20PB   AR20PB     2      33		 80     140    @NT_783001   @NT_783001   N        //Northern Coast
+AR10PB      AR10PB   AR10PB     4      35		 550    85     @NT_783002   @NT_783002   N        //Field of the Dead
+AR40PB      AR40PB   AR40PB     2      45		 755    60     @NT_783003   @NT_783003   N        //Northern Wood
+AR01PB      AR01PB   AR01PB     2      9		 665    110    @NT_783004   @NT_783004   N        //Wood of the Dead
+AR30PB      AR30PB   AR30PB     4      17		 850    95     @NT_783005   @NT_783005   N        //Northern Citadel
+AR60PB      AR60PB   AR60PB     4      11		 730    300    @NT_783006   @NT_783006   N        //Temple of the Black Hand
+AR0400      AR0400   MAPAR0400  2      28		 600    190    N            N            N        //Farmland
+AR1000      AR1000   MAPAR1000  3      51		 180    250    @NT_783010   @NT_783010   N        //Ulgoth's Beard

--- a/NTotSC/worldmap/bgee/bgee_links.tbl
+++ b/NTotSC/worldmap/bgee/bgee_links.tbl
@@ -1,0 +1,38 @@
+
+//NTotSC Area Links Table (with DSotSC)
+SRC_AREA  SRC_NWSE  TARGET_ARE  ENTRY_NAME  TRV_TIME  DEF_ENTRY  ENC1     ENC2     ENC3     ENC4     ENC5     ENC_PROB
+
+AR0400    N         AR01PB      Exit30PB    3         4          N        N        N        N        N        0
+AR0400    N         AR10PB      Exit01PB    3         4          N        N        N        N        N        0
+AR0400    E         AR30PB      Exit0400    5         8          N        N        N        N        N        0
+AR0900    N         AR30PB      Exit0400    6         8          N        N        N        N        N        0
+AR1000    E         AR10PB      Exit20PB    6         8          N        N        N        N        N        0
+AR1000    E         AR20PB      EXIT1000    4         4          N        N        N        N        N        0
+AR1900    N         AR60PB      Exit2900    4         4          N        N        N        N        N        0
+AR2400    N         AR60PB      Exit2900    4         4          N        N        N        N        N        0
+AR01PB    S         AR0400      N           3         1          N        N        N        N        N        0
+AR01PB    W         AR10PB      Exit01PB    3         2          N        N        N        N        N        0
+AR01PB    E         AR30PB      Exit01PB    4         8          N        N        N        N        N        0
+AR01PB    N         AR40PB      Exit10PB    3         4          N        N        N        N        N        0
+AR01PB    E         AR40PB      Exit10PB    3         4          N        N        N        N        N        0
+AR10PB    S         AR0400      Exit10PB    3         1          N        N        N        N        N        0
+AR10PB    S         AR1000      Exit1400    6         2          N        N        N        N        N        0
+AR10PB    E         AR01PB      Exit10PB    3         8          N        N        N        N        N        0
+AR10PB    W         AR20PB      Exit10PB    6         2          N        N        N        N        N        0
+AR10PB    E         AR40PB      Exit10PB    4         4          N        N        N        N        N        0
+AR10PB    N         AR40PB      Exit10PB    4         4          N        N        N        N        N        0
+AR20PB    E         AR0400      Exit10PB    8         1          AR5700   N        N        N        N        20
+AR20PB    S         AR1000      Exit1400    4         2          N        N        N        N        N        0
+AR20PB    E         AR10PB      Exit20PB    6         8          N	  	  N        N        N        N        0
+AR30PB    W         AR0400      Exit10PB    5         1          N        N        N        N        N        0
+AR30PB    W         AR0900      Exit0400    5         1          N        N        N        N        N        0
+AR30PB    W         AR01PB      Exit30PB    4         2          N        N        N        N        N        0
+AR30PB    W         AR40PB      Exit01PB    4         2          N        N        N        N        N        0
+AR40PB    S         AR01PB      Exit40PB    3         1          N        N        N        N        N        0
+AR40PB    S         AR10PB      Exit40PB    4         1          N        N        N        N        N        0
+AR40PB    S         AR30PB      Exit01PB    4         8          N        N        N        N        N        0
+AR60PB    S         AR2400      N		    4         1          N        N        N        N        N        0
+AR60PB    S         AR1900      N		    4         1          N        N        N        N        N        0
+AR60PB    W         DSC004      Exit60PB    6         1          N        N        N        N        N        0
+DSC002    N         AR60PB      Exit2900    6         1          N        N        N        N        N        0
+DSC004    N         AR60PB      Exit2900    6         1          N        N        N        N        N        0


### PR DESCRIPTION
Adding NTotSC areas to BGEE worldmap so that BGT Worldmap is no longer required for BGEE/SoD (i.e., non-EET) installs.
- Adds a call to ADD_WORLDMAP_TBL for BGEE games
- Adds new bgee_areas.tbl file with locations for NTotSC areas in BGEE Worldmap. File also has new coordinates for AR1000 (Ulgoth's Beard) and AR0400 (Farmland) to make room for NTotSC areas.
- Adds new bgge_links.tbl file with area links between NTotSC areas and connected BGEE (& DSotSC) areas. Updated links from original links.tbl to account for new relative positioning on BGEE Worldmap.
- Adds text for Ulgoth's Beard to worldmap.tra